### PR TITLE
Potential fix for colon keymap. 

### DIFF
--- a/app/src/main/java/de/bulling/barcodebuddyscanner/MainActivity.java
+++ b/app/src/main/java/de/bulling/barcodebuddyscanner/MainActivity.java
@@ -119,7 +119,8 @@ public class MainActivity extends AppCompatActivity {
 				keycode == KeyEvent.KEYCODE_NUMPAD_DOT ||
 				keycode == KeyEvent.KEYCODE_NUMPAD_ENTER ||
 				keycode == KeyEvent.KEYCODE_ENTER ||
-				keycode == KeyEvent.KEYCODE_MINUS);
+				keycode == KeyEvent.KEYCODE_MINUS||
+				keycode == KeyEvent.KEYCODE_SEMICOLON);
 	}
 
 	private void processKeypress(final KeyEvent event, final int keycode) {


### PR DESCRIPTION
Added additional keymap for semicolon to fix colons being removed from GrocyCode scans. 

Fixes Forceu/barcodebuddy-android#20